### PR TITLE
Add logout endpoint with token blacklisting support

### DIFF
--- a/internal/auth/blacklist.go
+++ b/internal/auth/blacklist.go
@@ -1,0 +1,49 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// TokenBlacklist provides token revocation operations.
+type TokenBlacklist interface {
+	Revoke(ctx context.Context, token string, ttl time.Duration) error
+	IsBlacklisted(ctx context.Context, token string) (bool, error)
+}
+
+// RedisTokenBlacklist stores blacklisted tokens in Redis.
+type RedisTokenBlacklist struct {
+	client *redis.Client
+	prefix string
+}
+
+// NewRedisTokenBlacklist constructs a Redis-backed blacklist implementation.
+func NewRedisTokenBlacklist(client *redis.Client) *RedisTokenBlacklist {
+	return &RedisTokenBlacklist{client: client, prefix: "auth:blacklist"}
+}
+
+// Revoke stores the token in Redis with a TTL matching the token's expiration.
+func (b *RedisTokenBlacklist) Revoke(ctx context.Context, token string, ttl time.Duration) error {
+	if ttl <= 0 {
+		ttl = time.Second
+	}
+	return b.client.Set(ctx, b.key(token), "revoked", ttl).Err()
+}
+
+// IsBlacklisted checks whether the token exists in the blacklist.
+func (b *RedisTokenBlacklist) IsBlacklisted(ctx context.Context, token string) (bool, error) {
+	res, err := b.client.Exists(ctx, b.key(token)).Result()
+	if err != nil {
+		return false, err
+	}
+	return res > 0, nil
+}
+
+func (b *RedisTokenBlacklist) key(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return b.prefix + ":" + hex.EncodeToString(sum[:])
+}

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -9,10 +9,13 @@ import (
 	"github.com/tasiuskenways/scalable-ecommerce/svc-user/internal/http/response"
 )
 
-const userIDContextKey = "user_id"
+const (
+	userIDContextKey = "user_id"
+	tokenContextKey  = "auth_token"
+)
 
 // Authenticated parses the Authorization header and injects the authenticated subject into the context.
-func Authenticated(issuer *auth.TokenIssuer) fiber.Handler {
+func Authenticated(issuer *auth.TokenIssuer, blacklist auth.TokenBlacklist) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		header := c.Get(fiber.HeaderAuthorization)
 		if header == "" {
@@ -29,12 +32,23 @@ func Authenticated(issuer *auth.TokenIssuer) fiber.Handler {
 			return response.Unauthorized(c, "missing bearer token")
 		}
 
+		if blacklist != nil {
+			revoked, err := blacklist.IsBlacklisted(c.Context(), token)
+			if err != nil {
+				return response.InternalError(c, "failed to validate token")
+			}
+			if revoked {
+				return response.Unauthorized(c, "token revoked")
+			}
+		}
+
 		sub, err := issuer.SubjectFromToken(token)
 		if err != nil {
 			return response.Unauthorized(c, "invalid or expired token")
 		}
 
 		c.Locals(userIDContextKey, sub)
+		c.Locals(tokenContextKey, token)
 		return c.Next()
 	}
 }
@@ -43,4 +57,10 @@ func Authenticated(issuer *auth.TokenIssuer) fiber.Handler {
 func UserID(c *fiber.Ctx) string {
 	userID, _ := c.Locals(userIDContextKey).(string)
 	return userID
+}
+
+// Token extracts the bearer token from the context.
+func Token(c *fiber.Ctx) string {
+	token, _ := c.Locals(tokenContextKey).(string)
+	return token
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -24,7 +24,7 @@ type Server struct {
 }
 
 // NewServer configures the HTTP server with middlewares and routes.
-func NewServer(cfg *config.Config, log *slog.Logger, issuer *auth.TokenIssuer, userHandler *handlers.UserHandler) (*Server, error) {
+func NewServer(cfg *config.Config, log *slog.Logger, issuer *auth.TokenIssuer, blacklist auth.TokenBlacklist, userHandler *handlers.UserHandler) (*Server, error) {
 	app := fiber.New(fiber.Config{
 		Prefork:               false,
 		DisableStartupMessage: true,
@@ -47,7 +47,7 @@ func NewServer(cfg *config.Config, log *slog.Logger, issuer *auth.TokenIssuer, u
 	handlers.RegisterHealthRoutes(app)
 
 	api := app.Group("/api/v1")
-	handlers.RegisterUserRoutes(api, userHandler, middleware.Authenticated(issuer))
+	handlers.RegisterUserRoutes(api, userHandler, middleware.Authenticated(issuer, blacklist))
 
 	return &Server{app: app, cfg: cfg}, nil
 }


### PR DESCRIPTION
## Summary
- add a Redis-backed token blacklist and wire it through the user service and auth middleware so revoked tokens are rejected
- expose an authenticated /users/logout route and unit tests to cover the new logout flow
- initialize the Redis client during HTTP server startup for blacklist usage

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d604bccd488328b8f032823e5612c3